### PR TITLE
Simplify the registration flow

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,10 +1,11 @@
 class Event < ActiveRecord::Base
-  before_save :ensure_one_current
   has_many :attendances
+  has_many :registrations, dependent: :destroy
 
   before_validation :generate_token, on: :create
-
   validates :token, presence: true, uniqueness: true
+
+  before_save :ensure_one_current
 
   def self.current
     find_by_current true

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -1,0 +1,11 @@
+class Registration < ActiveRecord::Base
+  belongs_to :event
+
+  def complete
+    transaction do
+      member = Member.create!(name: name, phone: phone_number, email: email_address)
+      event.attendances.create!(member: member)
+      destroy!
+    end
+  end
+end

--- a/db/migrate/20140916023141_create_users_table.rb
+++ b/db/migrate/20140916023141_create_users_table.rb
@@ -1,9 +1,9 @@
 class CreateUsersTable < ActiveRecord::Migration
   def change
     create_table :members do |t|
-	t.string :name
-	t.string :email
-	t.string :phone, limit: 10
+      t.string :name
+	    t.string :email
+	    t.string :phone, limit: 10
     end
   end
 end

--- a/db/migrate/20141014012505_create_registrations.rb
+++ b/db/migrate/20141014012505_create_registrations.rb
@@ -1,0 +1,12 @@
+class CreateRegistrations < ActiveRecord::Migration
+  def change
+    create_table :registrations do |t|
+      t.belongs_to :event, null: false
+      t.string :phone_number, null: false
+      t.string :name
+      t.string :email_address
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,28 +11,37 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141007164523) do
+ActiveRecord::Schema.define(version: 20141014012505) do
 
   create_table "attendances", force: true do |t|
-    t.integer "member_id"
-    t.integer "event_id"
+    t.integer "member_id", limit: 4
+    t.integer "event_id",  limit: 4
   end
 
   create_table "events", force: true do |t|
-    t.string  "name"
+    t.string  "name",    limit: 255
     t.date    "date"
-    t.boolean "current", default: false, null: false
-    t.string  "token",                   null: false
+    t.boolean "current", limit: 1,   default: false, null: false
+    t.string  "token",   limit: 255,                 null: false
   end
 
   add_index "events", ["token"], name: "index_events_on_token", unique: true, using: :btree
 
   create_table "members", force: true do |t|
-    t.string "name"
-    t.string "email"
-    t.string "phone", null: false
+    t.string "name",  limit: 255
+    t.string "email", limit: 255
+    t.string "phone", limit: 255, null: false
   end
 
   add_index "members", ["phone"], name: "index_members_on_phone", using: :btree
+
+  create_table "registrations", force: true do |t|
+    t.integer  "event_id",      limit: 4,   null: false
+    t.string   "phone_number",  limit: 255, null: false
+    t.string   "name",          limit: 255
+    t.string   "email_address", limit: 255
+    t.datetime "created_at",                null: false
+    t.datetime "updated_at",                null: false
+  end
 
 end


### PR DESCRIPTION
Put the burden of knowing when registration is needed on Handy. Instead of a new member first sending in their name, then their email address, and finally an event token, recognize when a new member is attempting to check in with an event token and ask for their name and email address.
