### PR TITLE
Verify twilio requests

### DIFF
--- a/app/controllers/sms/inbound_messages_controller.rb
+++ b/app/controllers/sms/inbound_messages_controller.rb
@@ -3,6 +3,8 @@ class Sms::InboundMessagesController < ApplicationController
   skip_before_action :verify_authenticity_token
   skip_authentication
 
+  before_action :validate_twilio_request
+
   def create
     TextMessage.create!(text_message_attributes).process_later
 
@@ -10,6 +12,14 @@ class Sms::InboundMessagesController < ApplicationController
   end
 
   private
+    def validate_twilio_request
+      head :forbidden unless valid_twilio_request?
+    end
+
+    def valid_twilio_request?
+      Twilio::Util::RequestValidator.new.validate(request.original_url, request.POST, request.headers['X-Twilio-Signature'].to_s)
+    end
+
     def text_message_attributes
       { phone_number: params[:From], body: params[:Body].strip }
     end

--- a/config/twilio.yml.sample
+++ b/config/twilio.yml.sample
@@ -4,6 +4,6 @@ development:
   phone_number:
 
 test:
-  account_sid:
-  auth_token:
-  phone_number:
+  account_sid: 9999999
+  auth_token: abcdefgh
+  phone_number: +15550194320

--- a/test/controllers/sms/inbound_messages_controller_test.rb
+++ b/test/controllers/sms/inbound_messages_controller_test.rb
@@ -1,11 +1,10 @@
 require 'test_helper'
 
 class Sms::InboundMessagesControllerTest < ActionController::TestCase
-  setup do
-    TextMessage.any_instance.expects(:process_later).once
-  end
-
   test 'create' do
+    expects_signature_validation
+    expects_text_message_processing
+
     assert_difference -> { TextMessage.count } do
       post :create, From: '+15558675309', Body: 'hello!'
     end
@@ -15,8 +14,29 @@ class Sms::InboundMessagesControllerTest < ActionController::TestCase
   end
 
   test 'create strips leading and trailing whitespace from text message bodies' do
+    expects_signature_validation
+    expects_text_message_processing
+
     post :create, From: '+15558675309', Body: '  hello, my friend!   '
     assert_response :ok
     assert_equal 'hello, my friend!', TextMessage.last.body
   end
+
+  test 'create requires a valid Twilio request signature' do
+    expects_signature_validation successful: false
+
+    assert_no_difference -> { TextMessage.count } do
+      post :create, From: '+15558675309', Body: 'hello!'
+    end
+    assert_response :forbidden
+  end
+
+  private
+    def expects_signature_validation(successful: true)
+      Twilio::Util::RequestValidator.any_instance.expects(:validate).returns(successful)
+    end
+
+    def expects_text_message_processing
+      TextMessage.any_instance.expects(:process_later).once
+    end
 end


### PR DESCRIPTION
Twilio [sends a signature for its requests](https://www.twilio.com/docs/security) in the `X-Twilio-Signature` header. The Twilio client gem provides a tool for verifying the signature. We can use this to lock down the inbound text messages endpoint and insulate Handy from malicious third-party messages.